### PR TITLE
Prevent errors in miss_case_pct

### DIFF
--- a/R/tidy-miss-family.R
+++ b/R/tidy-miss-family.R
@@ -21,7 +21,6 @@ miss_df_pct <- function(data){
     # test for dataframe
   } else if(inherits(data, "data.frame")){
     temp <- mean(is.na(data))
-    temp * 100
     } else stop("Input must inherit from data.frame", call. = FALSE)
 
 }
@@ -82,8 +81,20 @@ miss_case_pct <- function(data){
     # which rows are complete?
     stats::complete.cases() %>%
     mean()
-
-  (1 - temp) * 100
+   
+    # Return 100 if temp is 1
+    # Prevent error when all the rows contain a NA and then mean is 1
+    # so (1 -1)*100 = 0, whereas function should return 100.
+    if(temp == 1){
+      return(100)
+    } else if (temp == 0){
+      # Return 0 if temp is 0
+      # Prevent error when no row contains a NA and then mean is 0
+      # so (1 -0)*100 = 100, whereas function should return 0.
+      return(0)
+    } else {
+      return((1 - temp) * 100)
+    }
   } else stop("Input must inherit from data.frame", call. = FALSE)
   # previous
   # casemissingpct <- 1-mean(complete.cases(dat))*100


### PR DESCRIPTION
## Description

Changes in `miss_case_pct`

## Details

Current `miss_case_pct(iris)` return 100, whereas it should return 0 (no NA in this dataset). 
-> `mean(is.na(iris))` is 0, so `temp` is not right : `(1-0)*100 = 100`, whereas there's 0% NA in `iris`.

Also, `miss_case_pct(df)` should return 100 if all the content of `df` is NA (returns 0 with the current function). 
-> `mean(is.na(df))` is 1, so `temp` is not right `(1-1)*100 = 0`, whereas there's 100% NA in `df`.

Best, 

Colin